### PR TITLE
Keep organization cards compact after search

### DIFF
--- a/components/organization-card.tsx
+++ b/components/organization-card.tsx
@@ -43,7 +43,8 @@ export function OrganizationCard({
       href={`/organizations/${org.slug}`}
       prefetch={true}
       className={cn(
-        "block bg-white border border-gray-200 rounded-xl p-5 hover:shadow-md hover:border-gray-300 transition-all w-full",
+        "block bg-white border border-gray-200 rounded-xl p-5 hover:shadow-md hover:border-gray-300 transition-all",
+        "w-full max-w-[380px] sm:max-w-[420px]",
         "dark:bg-card dark:border-border dark:hover:border-gray-600",
         className
       )}


### PR DESCRIPTION
## Summary
- cap organization card width so it doesn't stretch when fewer results are shown
- retain existing styling/hover while keeping cards at a consistent size across grid layouts

## Rationale
On /organizations the cards grew to full width when search results were narrow; adding a max width preserves the compact card shape.

## Changes
- add responsive max-width to the organization card container while keeping it full-width within that cap

## Test Plan
- not run (UI tweak only)

Fixes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced organization card layout with responsive width adjustments for improved visual consistency and spacing across different screen sizes and devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->