### PR TITLE
fix: replace organization IDs with names in mentors table (#85)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
-
+.env
 # testing
 /coverage
 

--- a/app/yearly/[slug]/page.tsx
+++ b/app/yearly/[slug]/page.tsx
@@ -433,7 +433,7 @@ export default async function YearlyPage({
               
               <MentorsContributorsTable 
                 data={data.projects.map(p => ({
-                   org_name: organizations.find(o => o.slug === p.org_slug)?.name || p.org_slug,
+                   org_name: organizations.find(o => o.slug === p.org_slug)?.name || p.title,
                    org_slug: p.org_slug,
                    mentors: p.mentors || [],
                    contributors: p.contributor ? [p.contributor] : []


### PR DESCRIPTION
### What this PR fixes
Organization IDs were being displayed instead of organization names
in the Mentors & Contributors table on yearly pages.

### Changes made
- Fixed organization name mapping logic
- Ensured correct fallback values

### Related issue
Fixes #85

### Testing
- Tested locally on `/yearly/google-summer-of-code-2016`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization name display in the yearly contributors table to show project titles as fallback when organization information is unavailable.

* **Chores**
  * Updated .gitignore configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->