### PR TITLE
fix: mobile alignment for homepage feature blocks

### DIFF
--- a/components/value-blocks.tsx
+++ b/components/value-blocks.tsx
@@ -59,14 +59,14 @@ export function PreviousEditionsBlock() {
               unoptimized
             />
           </div>
-          <div className="flex gap-4 flex-col flex-1 items-center text-center">
+          <div className="flex gap-4 flex-col flex-1 items-center text-center lg:items-start lg:text-left">
             <div>
               <Badge variant="outline" className="gap-2">
                 <History className="size-3" />
                 Previous Editions
               </Badge>
             </div>
-            <div className="flex gap-2 flex-col items-center text-center">
+            <div className="flex gap-2 flex-col items-center text-center lg:items-start">
               <h2 className="text-xl md:text-3xl lg:text-5xl tracking-tighter lg:max-w-xl font-regular">
                 Learn from Past GSoC Years
               </h2>
@@ -141,14 +141,14 @@ export function AnalyticsBlock() {
               unoptimized
             />
           </div>
-          <div className="flex gap-4 flex-col flex-1 items-center text-center">
+          <div className="flex gap-4 flex-col flex-1 items-center text-center lg:items-start lg:text-left">
             <div>
               <Badge variant="outline" className="gap-2">
                 <BarChart3 className="size-3" />
                 Analytics
               </Badge>
             </div>
-            <div className="flex gap-2 flex-col items-center text-center">
+            <div className="flex gap-2 flex-col items-center text-center lg:items-start">
               <h2 className="text-xl md:text-3xl lg:text-5xl tracking-tighter lg:max-w-xl font-regular">
                 Data-Driven Insights
               </h2>

--- a/components/value-blocks.tsx
+++ b/components/value-blocks.tsx
@@ -15,7 +15,7 @@ export function OrganizationsBlock() {
                 Organizations
               </Badge>
             </div>
-            <div className="flex gap-2 flex-col items-center text-center lg:items-end">
+            <div className="flex gap-2 flex-col items-center text-center lg:items-end lg:text-right">
               <h2 className="text-xl md:text-3xl lg:text-5xl tracking-tighter lg:max-w-xl font-regular">
                 Explore 200+ GSoC Organizations
               </h2>
@@ -66,7 +66,7 @@ export function PreviousEditionsBlock() {
                 Previous Editions
               </Badge>
             </div>
-            <div className="flex gap-2 flex-col items-center text-center lg:items-start">
+            <div className="flex gap-2 flex-col items-center text-center lg:items-start lg:text-left">
               <h2 className="text-xl md:text-3xl lg:text-5xl tracking-tighter lg:max-w-xl font-regular">
                 Learn from Past GSoC Years
               </h2>
@@ -97,7 +97,7 @@ export function TechStackBlock() {
                 Tech Stack
               </Badge>
             </div>
-            <div className="flex gap-2 flex-col items-center text-center lg:items-end">
+            <div className="flex gap-2 flex-col items-center text-center lg:items-end lg:text-right">
               <h2 className="text-xl md:text-3xl lg:text-5xl tracking-tighter lg:max-w-xl font-regular">
                 Find Orgs by Technology
               </h2>
@@ -148,7 +148,7 @@ export function AnalyticsBlock() {
                 Analytics
               </Badge>
             </div>
-            <div className="flex gap-2 flex-col items-center text-center lg:items-start">
+            <div className="flex gap-2 flex-col items-center text-center lg:items-start lg:text-left">
               <h2 className="text-xl md:text-3xl lg:text-5xl tracking-tighter lg:max-w-xl font-regular">
                 Data-Driven Insights
               </h2>

--- a/components/value-blocks.tsx
+++ b/components/value-blocks.tsx
@@ -8,21 +8,22 @@ export function OrganizationsBlock() {
     <section className="w-full py-12 lg:py-12">
       <div className="max-w-5xl mx-auto px-6 lg:px-12">
         <div className="flex flex-col lg:flex-row gap-10 lg:items-center lg:justify-center">
-          <div className="flex gap-4 flex-col flex-1 lg:items-end lg:text-right">
+          <div className="flex gap-4 flex-col flex-1 items-center text-center lg:items-end lg:text-right">
             <div>
               <Badge variant="outline" className="gap-2">
                 <Building2 className="size-3" />
                 Organizations
               </Badge>
             </div>
-            <div className="flex gap-2 flex-col lg:items-end">
+            <div className="flex gap-2 flex-col items-center text-center lg:items-end">
               <h2 className="text-xl md:text-3xl lg:text-5xl tracking-tighter lg:max-w-xl font-regular">
                 Explore 200+ GSoC Organizations
               </h2>
               <p className="text-lg max-w-xl lg:max-w-sm leading-relaxed tracking-tight text-muted-foreground">
-                Browse through all participating GSoC organizations with detailed 
-                profiles, tech stacks, project ideas, and historical performance data. 
-                Filter by language, category, or beginner-friendliness to find your perfect match.
+                Browse through all participating GSoC organizations with
+                detailed profiles, tech stacks, project ideas, and historical
+                performance data. Filter by language, category, or
+                beginner-friendliness to find your perfect match.
               </p>
             </div>
           </div>
@@ -58,21 +59,22 @@ export function PreviousEditionsBlock() {
               unoptimized
             />
           </div>
-          <div className="flex gap-4 flex-col flex-1">
+          <div className="flex gap-4 flex-col flex-1 items-center text-center">
             <div>
               <Badge variant="outline" className="gap-2">
                 <History className="size-3" />
                 Previous Editions
               </Badge>
             </div>
-            <div className="flex gap-2 flex-col">
+            <div className="flex gap-2 flex-col items-center text-center">
               <h2 className="text-xl md:text-3xl lg:text-5xl tracking-tighter lg:max-w-xl font-regular">
                 Learn from Past GSoC Years
               </h2>
               <p className="text-lg max-w-xl lg:max-w-sm leading-relaxed tracking-tight text-muted-foreground">
-                Access comprehensive data from GSoC 2016 to 2025. Study past projects, 
-                understand what worked, see mentor patterns, and identify organizations 
-                with consistent participation and high success rates.
+                Access comprehensive data from GSoC 2016 to 2025. Study past
+                projects, understand what worked, see mentor patterns, and
+                identify organizations with consistent participation and high
+                success rates.
               </p>
             </div>
           </div>
@@ -88,21 +90,22 @@ export function TechStackBlock() {
     <section className="w-full py-12 lg:py-12">
       <div className="max-w-5xl mx-auto px-6 lg:px-12">
         <div className="flex flex-col lg:flex-row gap-10 lg:items-center lg:justify-center">
-          <div className="flex gap-4 flex-col flex-1 lg:items-end lg:text-right">
+          <div className="flex gap-4 flex-col flex-1 items-center text-center lg:items-end lg:text-right">
             <div>
               <Badge variant="outline" className="gap-2">
                 <Code2 className="size-3" />
                 Tech Stack
               </Badge>
             </div>
-            <div className="flex gap-2 flex-col lg:items-end">
+            <div className="flex gap-2 flex-col items-center text-center lg:items-end">
               <h2 className="text-xl md:text-3xl lg:text-5xl tracking-tighter lg:max-w-xl font-regular">
                 Find Orgs by Technology
               </h2>
               <p className="text-lg max-w-xl lg:max-w-sm leading-relaxed tracking-tight text-muted-foreground">
-                Python, JavaScript, Rust, Go, or any other language — filter organizations 
-                by your preferred tech stack. See which technologies are trending in GSoC 
-                and match your skills with the right opportunities.
+                Python, JavaScript, Rust, Go, or any other language — filter
+                organizations by your preferred tech stack. See which
+                technologies are trending in GSoC and match your skills with the
+                right opportunities.
               </p>
             </div>
           </div>
@@ -138,21 +141,22 @@ export function AnalyticsBlock() {
               unoptimized
             />
           </div>
-          <div className="flex gap-4 flex-col flex-1">
+          <div className="flex gap-4 flex-col flex-1 items-center text-center">
             <div>
               <Badge variant="outline" className="gap-2">
                 <BarChart3 className="size-3" />
                 Analytics
               </Badge>
             </div>
-            <div className="flex gap-2 flex-col">
+            <div className="flex gap-2 flex-col items-center text-center">
               <h2 className="text-xl md:text-3xl lg:text-5xl tracking-tighter lg:max-w-xl font-regular">
                 Data-Driven Insights
               </h2>
               <p className="text-lg max-w-xl lg:max-w-sm leading-relaxed tracking-tight text-muted-foreground">
-                Make informed decisions with visual analytics. Track organization trends, 
-                compare acceptance rates, analyze project difficulty distributions, and 
-                discover patterns that increase your selection chances.
+                Make informed decisions with visual analytics. Track
+                organization trends, compare acceptance rates, analyze project
+                difficulty distributions, and discover patterns that increase
+                your selection chances.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
 fix: mobile alignment for homepage feature blocks

## Testing
- before
<img width="1913" height="979" alt="image" src="https://github.com/user-attachments/assets/ce389102-84d5-44bc-af58-05afe4510543" />


- after#
<img width="1916" height="960" alt="image" src="https://github.com/user-attachments/assets/b368e998-e892-4f3e-bda7-282bdd010b48" />


closes: #98 

## Checklist
- [x] One logical change per PR
- [x] PR description is complete
- [x] No refactors without prior discussion
- [x] Follows existing project structure



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Centered text and content across value blocks (Organizations, Previous Editions, Tech Stack, Analytics), replacing prior right-aligned layouts for improved visual consistency and readability.
  * Adjusted responsive alignment and text wrapping so headings and paragraphs present neatly at different screen sizes while preserving content order and meaning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->