### PR TITLE
fix: normalize tech stacks and organization names

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "prisma generate",
     "prepare": "husky",
     "generate:organizations": "node scripts/generate-organizations-data.js",
-    "generate:tech-stack": "node scripts/generate-tech-stack-data.js",
+    "generate:tech-stack": "npx tsx scripts/generate-tech-stack-data.ts",
     "generate:topics": "node scripts/generate-topics-data.js",
     "gsoc:fetch": "npx tsx scripts/fetch-year-data.ts",
     "gsoc:transform": "npx tsx scripts/transform-year-organizations.ts",

--- a/scripts/generate-tech-stack-data.ts
+++ b/scripts/generate-tech-stack-data.ts
@@ -1,56 +1,37 @@
 /**
  * Generate Tech Stack Page JSON Data
- * 
+ *
  * This script queries all organizations and generates:
  * 1. index.json - For /tech-stack index page
  * 2. {slug}.json - One file per technology
- * 
- * Run with: node scripts/generate-tech-stack-data.js
+ *
+ * Run with: npx tsx scripts/generate-tech-stack-data.ts
  */
 
-const { PrismaClient } = require('@prisma/client');
-const fs = require('fs');
-const path = require('path');
+import { PrismaClient } from "@prisma/client";
+import fs from "fs";
+import path from "path";
+import { getStandardTechName } from "./normalize-data.js";
 
 const prisma = new PrismaClient();
 
-const OUTPUT_DIR = path.join(__dirname, '..', 'new-api-details', 'tech-stack');
+const OUTPUT_DIR = path.join(process.cwd(), "new-api-details", "tech-stack");
 const YEARS = [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025];
 
-// Tech name normalization map
-const TECH_NORMALIZATIONS = {
-    'c++': 'cpp',
-    'c/c++': 'cpp',
-    'c #': 'csharp',
-    'c#': 'csharp',
-    '.net': 'dotnet',
-    'node.js': 'nodejs',
-    'node': 'nodejs',
-    'react.js': 'react',
-    'reactjs': 'react',
-    'vue.js': 'vue',
-    'vuejs': 'vue',
-    'angular.js': 'angular',
-    'angularjs': 'angular',
-};
-
-function normalizeSlug(techName) {
-    const lower = techName.toLowerCase().trim();
-    // Check normalization map first
-    if (TECH_NORMALIZATIONS[lower]) {
-        return TECH_NORMALIZATIONS[lower];
-    }
-    // Generate slug
-    return lower.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+function normalizeSlug(techName: string): string {
+    const standard = getStandardTechName(techName);
+    return standard
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
 }
 
-function normalizeName(techName) {
-    // Capitalize properly
-    return techName.trim();
+function normalizeName(techName: string): string {
+    return getStandardTechName(techName);
 }
 
 async function generateTechStackData() {
-    console.log('[START] Generating tech stack data...');
+    console.log("[START] Generating tech stack data...");
 
     // Ensure output directory exists
     if (!fs.existsSync(OUTPUT_DIR)) {
@@ -58,7 +39,7 @@ async function generateTechStackData() {
     }
 
     // 1. Fetch all organizations with tech data
-    console.log('[FETCH] Loading organizations from database...');
+    console.log("[FETCH] Loading organizations from database...");
     const organizations = await prisma.organizations.findMany({
         select: {
             id: true,
@@ -78,8 +59,16 @@ async function generateTechStackData() {
     console.log(`[FETCH] Loaded ${organizations.length} organizations`);
 
     // 2. Build tech map with normalized names
-    console.log('[PROCESS] Building technology index...');
-    const techMap = new Map(); // slug -> { name, orgs, byYear }
+    console.log("[PROCESS] Building technology index...");
+    const techMap = new Map<
+        string,
+        {
+            name: string;
+            slug: string;
+            orgs: Map<string, object>;
+            byYear: Record<number, { orgCount: number; projectCount: number }>;
+        }
+    >();
 
     organizations.forEach((org) => {
         (org.technologies || []).forEach((tech) => {
@@ -90,12 +79,12 @@ async function generateTechStackData() {
                 techMap.set(slug, {
                     name: name,
                     slug: slug,
-                    orgs: new Map(), // slug -> org data
-                    byYear: {}, // year -> { orgCount, projectCount }
+                    orgs: new Map(),
+                    byYear: {},
                 });
             }
 
-            const techData = techMap.get(slug);
+            const techData = techMap.get(slug)!;
 
             // Add org if not already added
             if (!techData.orgs.has(org.slug)) {
@@ -103,7 +92,7 @@ async function generateTechStackData() {
                     slug: org.slug,
                     name: org.name,
                     logo_url: org.logo_r2_url || org.img_r2_url || org.image_url,
-                    category: org.category || 'Other',
+                    category: org.category || "Other",
                     total_projects: org.total_projects || 0,
                     is_currently_active: org.is_currently_active || false,
                     active_years: org.active_years || [],
@@ -121,7 +110,7 @@ async function generateTechStackData() {
                     // Get project count for this year
                     if (org.years) {
                         const yearKey = `year_${year}`;
-                        const yearData = org.years[yearKey];
+                        const yearData = (org.years as Record<string, { num_projects?: number } | null>)[yearKey];
                         if (yearData && yearData.num_projects) {
                             techData.byYear[year].projectCount += yearData.num_projects;
                         }
@@ -134,16 +123,22 @@ async function generateTechStackData() {
     console.log(`[PROCESS] Found ${techMap.size} unique technologies`);
 
     // 3. Generate per-tech JSON files
-    console.log('[GENERATE] Creating per-technology JSON files...');
-    const allTechs = [];
+    console.log("[GENERATE] Creating per-technology JSON files...");
+    const allTechs: { name: string; slug: string; org_count: number; project_count: number }[] = [];
     let generatedCount = 0;
 
     for (const [slug, techData] of techMap.entries()) {
-        const orgsArray = Array.from(techData.orgs.values());
+        const orgsArray = Array.from(techData.orgs.values()) as {
+            slug: string;
+            name: string;
+            total_projects: number;
+        }[];
         const totalProjects = orgsArray.reduce((sum, o) => sum + (o.total_projects || 0), 0);
 
         // Calculate metrics
-        const activeYears = Object.keys(techData.byYear).map(Number).filter(y => techData.byYear[y].orgCount > 0);
+        const activeYears = Object.keys(techData.byYear)
+            .map(Number)
+            .filter((y) => techData.byYear[y].orgCount > 0);
         const firstYear = activeYears.length > 0 ? Math.min(...activeYears) : 2016;
         const latestYear = activeYears.length > 0 ? Math.max(...activeYears) : 2025;
 
@@ -155,9 +150,8 @@ async function generateTechStackData() {
             metrics: {
                 org_count: orgsArray.length,
                 project_count: totalProjects,
-                avg_projects_per_org: orgsArray.length > 0
-                    ? Math.round((totalProjects / orgsArray.length) * 10) / 10
-                    : 0,
+                avg_projects_per_org:
+                    orgsArray.length > 0 ? Math.round((totalProjects / orgsArray.length) * 10) / 10 : 0,
                 first_year_used: firstYear,
                 latest_year_used: latestYear,
             },
@@ -194,16 +188,15 @@ async function generateTechStackData() {
     console.log(`[GENERATE] Created ${generatedCount} technology files`);
 
     // 4. Generate index.json
-    console.log('[GENERATE] Creating index.json...');
+    console.log("[GENERATE] Creating index.json...");
 
-    // Sort for various charts
     const sortedByOrgs = [...allTechs].sort((a, b) => b.org_count - a.org_count);
     const sortedByProjects = [...allTechs].sort((a, b) => b.project_count - a.project_count);
 
     // Build popularity by year for top techs
-    const popularityByYear = {};
+    const popularityByYear: Record<string, { year: number; count: number }[]> = {};
     sortedByOrgs.slice(0, 20).forEach((tech) => {
-        const techData = techMap.get(tech.slug);
+        const techData = techMap.get(tech.slug)!;
         popularityByYear[tech.slug] = YEARS.map((year) => ({
             year,
             count: techData.byYear[year]?.orgCount || 0,
@@ -213,12 +206,15 @@ async function generateTechStackData() {
     // Calculate fastest growing (compare 2020 vs 2025)
     const fastestGrowing = allTechs
         .map((tech) => {
-            const techData = techMap.get(tech.slug);
+            const techData = techMap.get(tech.slug)!;
             const count2020 = techData.byYear[2020]?.orgCount || 0;
             const count2025 = techData.byYear[2025]?.orgCount || 0;
-            const growth = count2020 > 0
-                ? ((count2025 - count2020) / count2020) * 100
-                : count2025 > 5 ? 500 : 0; // Only show high growth for new significant techs
+            const growth =
+                count2020 > 0
+                    ? ((count2025 - count2020) / count2020) * 100
+                    : count2025 > 5
+                        ? 500
+                        : 0;
             return {
                 slug: tech.slug,
                 name: tech.name,
@@ -227,40 +223,42 @@ async function generateTechStackData() {
                 last_year_count: count2025,
             };
         })
-        .filter((t) => t.last_year_count >= 3) // Must have at least 3 orgs in 2025
+        .filter((t) => t.last_year_count >= 3)
         .sort((a, b) => b.growth_pct - a.growth_pct)
         .slice(0, 10);
 
-    // Most selections (org selections over years)
     const mostSelections = sortedByOrgs.slice(0, 10).map((tech) => {
-        const techData = techMap.get(tech.slug);
+        const techData = techMap.get(tech.slug)!;
         return {
             name: tech.name,
             slug: tech.slug,
             total: tech.org_count,
-            byYear: YEARS.slice(-6).reverse().map((year) => ({
-                year,
-                count: techData.byYear[year]?.orgCount || 0,
-            })),
+            byYear: YEARS.slice(-6)
+                .reverse()
+                .map((year) => ({
+                    year,
+                    count: techData.byYear[year]?.orgCount || 0,
+                })),
         };
     });
 
-    // Most projects
     const mostProjects = sortedByProjects.slice(0, 10).map((tech) => {
-        const techData = techMap.get(tech.slug);
+        const techData = techMap.get(tech.slug)!;
         return {
             name: tech.name,
             slug: tech.slug,
             total: tech.project_count,
-            byYear: YEARS.slice(-6).reverse().map((year) => ({
-                year,
-                count: techData.byYear[year]?.projectCount || 0,
-            })),
+            byYear: YEARS.slice(-6)
+                .reverse()
+                .map((year) => ({
+                    year,
+                    count: techData.byYear[year]?.projectCount || 0,
+                })),
         };
     });
 
     const indexData = {
-        slug: 'tech-stack-index',
+        slug: "tech-stack-index",
         published_at: new Date().toISOString(),
 
         metrics: {
@@ -268,7 +266,7 @@ async function generateTechStackData() {
             total_organizations: organizations.length,
         },
 
-        all_techs: sortedByOrgs, // Pre-sorted by org count
+        all_techs: sortedByOrgs,
 
         charts: {
             top_tech_by_orgs: sortedByOrgs.slice(0, 15).map((t) => ({
@@ -293,12 +291,11 @@ async function generateTechStackData() {
         },
     };
 
-    const indexPath = path.join(OUTPUT_DIR, 'index.json');
+    const indexPath = path.join(OUTPUT_DIR, "index.json");
     fs.writeFileSync(indexPath, JSON.stringify(indexData, null, 2));
-    console.log('[GENERATE] Created index.json');
+    console.log("[GENERATE] Created index.json");
 
-    // Summary
-    console.log('\n[DONE] Tech stack data generation complete!');
+    console.log("\n[DONE] Tech stack data generation complete!");
     console.log(`  - Total technologies: ${allTechs.length}`);
     console.log(`  - Total organizations: ${organizations.length}`);
     console.log(`  - Files created: ${generatedCount + 1}`);
@@ -306,8 +303,8 @@ async function generateTechStackData() {
     await prisma.$disconnect();
 }
 
-// Run
-generateTechStackData().catch((error) => {
-    console.error('[ERROR]', error);
+generateTechStackData().catch(async (error) => {
+    console.error("[ERROR]", error);
+    await prisma.$disconnect();
     process.exit(1);
 });

--- a/scripts/normalize-data.ts
+++ b/scripts/normalize-data.ts
@@ -1,0 +1,146 @@
+import fs from "fs";
+import path from "path";
+
+// Each sub-array has the "Standard Name" first, followed by its alternate variations.
+export const TECH_ALIASES = [
+  ["Vue", "vue.js", "vuejs"],
+  ["React", "react.js", "reactjs"],
+  ["C++", "c/c++", "cpp"],
+  ["C#", "c #", "csharp", ".net", "dotnet"],
+  ["Node.js", "node", "nodejs"],
+  ["Angular", "angular.js", "angularjs"],
+  ["Python", "python3", "python2"],
+  ["JavaScript", "js", "vanilla js"],
+  ["TypeScript", "ts"],
+  ["Go", "golang"],
+  ["Ruby", "ruby on rails", "rails"],
+  ["PostgreSQL", "postgres", "psql"],
+  ["MongoDB", "mongo", "mongodb"],
+  ["MySQL", "mysql"],
+  ["Docker", "docker"],
+  ["Kubernetes", "k8s"],
+  ["AWS", "amazon web services", "aws cloud"],
+  ["GCP", "google cloud platform", "google cloud"],
+  ["Azure", "microsoft azure"],
+];
+
+// Each sub-array has the "Standard Name" first, followed by its alternate variations.
+export const ORG_ALIASES: string[][] = [
+  ["Ceph Foundation", "ceph", "ceph-foundation"],
+  ["OpenMS", "openms", "openms-inc"]
+];
+
+/**
+ * Normalizes a technology name.
+ * If the raw name matches any of the variations (case-insensitive),
+ * it returns the Standard Name (the first element of the array).
+ * Otherwise, it falls back to the original trimmed name.
+ */
+export function getStandardTechName(raw: string): string {
+  const lower = raw.toLowerCase().trim();
+  for (const aliases of TECH_ALIASES) {
+    const [standard, ...alts] = aliases;
+    if (standard.toLowerCase() === lower || alts.map(a => a.toLowerCase()).includes(lower)) {
+      return standard;
+    }
+  }
+  return raw.trim();
+}
+
+/**
+ * Normalizes an organization name.
+ * Runs through ORG_ALIASES mapping.
+ */
+export function getStandardOrgName(raw: string): string {
+  const lower = raw.toLowerCase().trim();
+  for (const aliases of ORG_ALIASES) {
+    const [standard, ...alts] = aliases;
+    if (standard.toLowerCase() === lower || alts.map(a => a.toLowerCase()).includes(lower)) {
+      return standard;
+    }
+  }
+  return raw.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Run logic to modify new-api-details/organizations/*.json
+// ---------------------------------------------------------------------------
+
+async function main() {
+  // Only execute logic if run directly (not imported)
+  // Using import.meta.url is the reliable ESM pattern, avoids __filename issues with tsx
+  const { fileURLToPath } = await import("url");
+  const scriptPath = fileURLToPath(import.meta.url);
+  if (process.argv[1] !== scriptPath) return;
+
+  const ROOT = process.cwd();
+  const ORGS_DIR = path.join(ROOT, "new-api-details", "organizations");
+
+  if (!fs.existsSync(ORGS_DIR)) {
+    console.error(`[ERROR] Directory not found: ${ORGS_DIR}`);
+    process.exit(1);
+  }
+
+  const files = fs
+    .readdirSync(ORGS_DIR)
+    .filter((f) => f.endsWith(".json") && f !== "index.json" && f !== "metadata.json");
+
+  console.log(`[START] Normalizing data for ${files.length} organization files...`);
+
+  let modifiedCount = 0;
+
+  for (const file of files) {
+    const filePath = path.join(ORGS_DIR, file);
+    try {
+      const dbBytes = fs.readFileSync(filePath, "utf-8");
+      const org = JSON.parse(dbBytes);
+
+      let hasChanges = false;
+
+      // Normalize technologies
+      if (Array.isArray(org.technologies)) {
+        const newTechs: string[] = [];
+        const seenTechs = new Set<string>();
+
+        for (const rawTech of org.technologies) {
+          const standard = getStandardTechName(rawTech);
+          if (!seenTechs.has(standard.toLowerCase())) {
+            newTechs.push(standard);
+            seenTechs.add(standard.toLowerCase());
+          }
+          if (standard !== rawTech) {
+            hasChanges = true;
+          }
+        }
+
+        if (org.technologies.length !== newTechs.length) {
+          hasChanges = true;
+        }
+
+        if (hasChanges) {
+          org.technologies = newTechs;
+        }
+      }
+
+      // Normalize Organization Name
+      if (org.name) {
+        const stdOrgName = getStandardOrgName(org.name);
+        if (stdOrgName !== org.name) {
+          org.name = stdOrgName;
+          hasChanges = true;
+        }
+      }
+
+      if (hasChanges) {
+        fs.writeFileSync(filePath, JSON.stringify(org, null, 2) + "\n");
+        modifiedCount++;
+      }
+    } catch (e) {
+      console.error(`[ERROR] Failed processing ${file}:`, e);
+    }
+  }
+
+  console.log(`[DONE] Modified ${modifiedCount} files. Data normalization complete!`);
+}
+
+main();

--- a/scripts/regenerate-tech-topics-from-json.ts
+++ b/scripts/regenerate-tech-topics-from-json.ts
@@ -16,6 +16,7 @@
 
 import fs from "fs";
 import path from "path";
+import { getStandardTechName, getStandardOrgName } from "./normalize-data.js";
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -52,28 +53,11 @@ interface OrgData {
 }
 
 // ---------------------------------------------------------------------------
-// Tech name normalization (mirrors generate-tech-stack-data.js)
+// Tech name normalization
 // ---------------------------------------------------------------------------
-const TECH_NORMALIZATIONS: Record<string, string> = {
-  "c++": "cpp",
-  "c/c++": "cpp",
-  "c #": "csharp",
-  "c#": "csharp",
-  ".net": "dotnet",
-  "node.js": "nodejs",
-  node: "nodejs",
-  "react.js": "react",
-  reactjs: "react",
-  "vue.js": "vue",
-  vuejs: "vue",
-  "angular.js": "angular",
-  angularjs: "angular",
-};
-
 function normalizeSlug(techName: string): string {
-  const lower = techName.toLowerCase().trim();
-  if (TECH_NORMALIZATIONS[lower]) return TECH_NORMALIZATIONS[lower];
-  return lower.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  const standard = getStandardTechName(techName);
+  return standard.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
 function topicSlug(topicName: string): string {
@@ -124,7 +108,7 @@ function generateTechStack(orgs: OrgData[], YEARS: number[]) {
   orgs.forEach((org) => {
     (org.technologies || []).forEach((tech) => {
       const slug = normalizeSlug(tech);
-      const name = tech.trim();
+      const name = getStandardTechName(tech);
       if (!slug) return;
 
       if (!techMap.has(slug)) {

--- a/scripts/transform-year-organizations.ts
+++ b/scripts/transform-year-organizations.ts
@@ -18,6 +18,7 @@
 
 import fs from "fs";
 import path from "path";
+import { getStandardTechName, getStandardOrgName, TECH_ALIASES, ORG_ALIASES } from "./normalize-data.js";
 
 // ---------------------------------------------------------------------------
 // CLI args
@@ -150,7 +151,7 @@ async function main() {
 
   // 2. Read existing index & build name→slug map for fuzzy matching
   let existingIndex: {
-    organizations: Array<{ slug: string; name: string; [key: string]: unknown }>;
+    organizations: Array<{ slug: string; name: string;[key: string]: unknown }>;
   } = { organizations: [] };
   if (fs.existsSync(INDEX_FILE)) {
     existingIndex = JSON.parse(fs.readFileSync(INDEX_FILE, "utf-8"));
@@ -230,6 +231,37 @@ async function main() {
   const newCount = rawOrgs.filter((o) => resolveExistingSlug(o) === null).length;
   console.log(`[ANALYSIS] ${returningCount} returning orgs, ${newCount} first-time orgs`);
 
+  // Detect and Warn about Unknown/Unnormalized Data
+  console.log("\n[VALIDATION] Checking for unmapped standardizations...");
+  const knownTechs = new Set(TECH_ALIASES.map(a => a[0].toLowerCase()));
+  const knownOrgs = new Set(ORG_ALIASES.map(a => a[0].toLowerCase()));
+  const newTechsFound = new Set<string>();
+  const unmappedOrgsFound = new Set<string>();
+
+  for (const raw of rawOrgs) {
+    const stdOrg = getStandardOrgName(raw.name);
+    if (!knownOrgs.has(stdOrg.toLowerCase()) && !existingSlugs.has(raw.slug)) {
+      unmappedOrgsFound.add(stdOrg);
+    }
+    for (const tech of (raw.tech_tags || [])) {
+      const stdTech = getStandardTechName(tech);
+      if (!knownTechs.has(stdTech.toLowerCase())) {
+        newTechsFound.add(stdTech);
+      }
+    }
+  }
+
+  if (unmappedOrgsFound.size > 0) {
+    console.warn(`[WARN] Found ${unmappedOrgsFound.size} new/unmapped Organizations. Consider adding them to ORG_ALIASES in normalize-data.ts:`);
+    Array.from(unmappedOrgsFound).forEach(o => console.warn(`   - "${o}"`));
+  }
+  if (newTechsFound.size > 0) {
+    console.warn(`[WARN] Found ${newTechsFound.size} unmapped Technologies. Consider adding them to TECH_ALIASES in normalize-data.ts:`);
+    Array.from(newTechsFound).slice(0, 20).forEach(t => console.warn(`   - "${t}"`));
+    if (newTechsFound.size > 20) console.warn(`   ...and ${newTechsFound.size - 20} more.`);
+  }
+  console.log("");
+
   // Log all non-trivial matches (alias + name)
   console.log("[MATCHING] Non-trivial slug resolutions:");
   let matchLogCount = 0;
@@ -265,6 +297,7 @@ async function main() {
 
       existing.last_year = Math.max(existing.last_year || 0, YEAR);
       existing.is_currently_active = true;
+      existing.name = getStandardOrgName(raw.name);
 
       // Refresh description if the new one is more substantial
       if (raw.description && raw.description.length > (existing.description?.length || 0)) {
@@ -273,7 +306,7 @@ async function main() {
 
       // Merge technologies (union, preserving existing)
       const techSet = new Set([...(existing.technologies || [])]);
-      (raw.tech_tags || []).forEach((t: string) => techSet.add(t));
+      (raw.tech_tags || []).forEach((t: string) => techSet.add(getStandardTechName(t)));
       existing.technologies = Array.from(techSet);
 
       // Merge topics (union, preserving existing)
@@ -336,7 +369,7 @@ async function main() {
       const newOrg = {
         id: `new_${YEAR}_${raw.slug}`,
         slug: raw.slug,
-        name: raw.name,
+        name: getStandardOrgName(raw.name),
         category: raw.categories?.[0] || "Other",
         description: raw.description || raw.tagline || "",
         image_url: raw.logo_url || "",
@@ -347,7 +380,7 @@ async function main() {
         first_year: YEAR,
         last_year: YEAR,
         is_currently_active: true,
-        technologies: raw.tech_tags || [],
+        technologies: (raw.tech_tags || []).map(getStandardTechName),
         topics: raw.topic_tags || [],
         total_projects: 0,
         stats: {


### PR DESCRIPTION
## Summary
- Introduces a centralized 2D array mapping utility ([scripts/normalize-data.ts] to resolve duplicate and fragmented tech stacks (e.g., `vue.js` vs `vuejs`) and organization names.
- Updates data generation scripts ([scripts/generate-tech-stack-data.js] and [scripts/regenerate-tech-topics-from-json.ts] to seamlessly use this new `normalize-data` logic.
- Refactors [scripts/transform-year-organizations.ts] to log console warnings for maintainers whenever the script encounters unmapped new technologies or organizations in future datasets.

## Testing
- Ran the new data normalizer tool locally against `new-api-details/organizations/*.json` to unify tag datasets.
- Executed `npx tsx scripts/regenerate-tech-topics-from-json.ts` which verified that former fragmentations properly grouped into parent classifications (e.g., 12 orgs correctly rolled into the single "Vue" topic).
- Executed `npx tsx scripts/transform-year-organizations.ts` returning full validation logs flagging unmapped dataset variables. 
- Verified `pnpm build` completes normally without issues.

## Checklist
- [x] One logical change per PR
- [x] PR description is complete
- [x] No refactors without prior discussion
- [x] Follows existing project structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized normalization of technology and organization names applied across data workflows.
  * Validation warnings added to surface unmapped organizations and technologies.
  * Tech-stack generation now derives active years from data and produces more consistent outputs.

* **Chores**
  * Migrated data-processing tooling to TypeScript and updated the tech-stack generation command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->