### PR TITLE
feat: highlight comparison chart on technology hover

### DIFF
--- a/app/tech-stack/charts/stack-popularity-chart.tsx
+++ b/app/tech-stack/charts/stack-popularity-chart.tsx
@@ -39,6 +39,7 @@ export function StackPopularityChart({ data, availableTechs = [] }: StackPopular
   })
   const [searchQuery, setSearchQuery] = useState("")
   const [showDropdown, setShowDropdown] = useState(false)
+  const [activeTech, setActiveTech] = useState<string | null>(null)
 
   // Get all available techs from data if not provided
   const allTechs = useMemo(() => {
@@ -64,7 +65,7 @@ export function StackPopularityChart({ data, availableTechs = [] }: StackPopular
 
   if (!data || Object.keys(data).length === 0) {
     return (
-      <div className="h-[280px] flex items-center justify-center text-muted-foreground text-sm">
+      <div className="h-70 flex items-center justify-center text-muted-foreground text-sm">
         No popularity data available
       </div>
     );
@@ -211,7 +212,7 @@ export function StackPopularityChart({ data, availableTechs = [] }: StackPopular
 
       {/* Chart */}
       {stacks.length > 0 ? (
-        <div className="h-[280px] w-full">
+        <div className="h-70 w-full">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
               data={chartData}
@@ -243,13 +244,39 @@ export function StackPopularityChart({ data, availableTechs = [] }: StackPopular
                 }}
               />
               <Legend 
-                wrapperStyle={{ fontSize: "11px" }}
+                wrapperStyle={{ fontSize: "11px", paddingTop: "16px" }}
                 iconType="circle"
                 iconSize={8}
-                formatter={(value: string) => {
-                  const displayName = allTechs.find(t => t.name === value)?.displayName || value
-                  return displayName
-                }}
+                content={({ payload }) => (
+                  <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 px-2">
+                    {payload?.map((entry) => {
+                      const techName = String(entry.value)
+                      const displayName = allTechs.find(t => t.name === techName)?.displayName || techName
+                      const isActive = activeTech === techName
+
+                      return (
+                        <button
+                          key={techName}
+                          type="button"
+                          onMouseEnter={() => setActiveTech(techName)}
+                          onMouseLeave={() => setActiveTech(null)}
+                          onFocus={() => setActiveTech(techName)}
+                          onBlur={() => setActiveTech(null)}
+                          className={`inline-flex items-center gap-2 rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                            isActive ? "bg-teal-100 text-teal-900" : "text-muted-foreground hover:text-foreground hover:bg-accent"
+                          }`}
+                          aria-label={`Highlight ${displayName}`}
+                        >
+                          <span
+                            className="inline-block h-2.5 w-2.5 rounded-full"
+                            style={{ backgroundColor: entry.color }}
+                          />
+                          <span>{displayName}</span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
               />
               {stacks.map((stack, index) => (
                 <Line
@@ -258,16 +285,22 @@ export function StackPopularityChart({ data, availableTechs = [] }: StackPopular
                   dataKey={stack}
                   name={stack}
                   stroke={LINE_COLORS[index % LINE_COLORS.length]}
-                  strokeWidth={2}
-                  dot={{ fill: LINE_COLORS[index % LINE_COLORS.length], strokeWidth: 0, r: 4 }}
-                  activeDot={{ r: 6 }}
+                  strokeWidth={activeTech === stack ? 4 : 2}
+                  strokeOpacity={activeTech && activeTech !== stack ? 0.2 : 1}
+                  dot={{
+                    fill: LINE_COLORS[index % LINE_COLORS.length],
+                    strokeWidth: 0,
+                    r: activeTech === stack ? 5 : 4,
+                    fillOpacity: activeTech && activeTech !== stack ? 0.2 : 1,
+                  }}
+                  activeDot={{ r: activeTech === stack ? 8 : 6 }}
                 />
               ))}
             </LineChart>
           </ResponsiveContainer>
         </div>
       ) : (
-        <div className="h-[280px] flex items-center justify-center text-muted-foreground text-sm border border-dashed rounded-md">
+        <div className="h-70 flex items-center justify-center text-muted-foreground text-sm border border-dashed rounded-md">
           Select technologies to compare
         </div>
       )}

--- a/app/tech-stack/tech-stack-client-wrapper.tsx
+++ b/app/tech-stack/tech-stack-client-wrapper.tsx
@@ -188,7 +188,11 @@ export function TechStackClientWrapper({ techs }: TechStackClientWrapperProps) {
 /**
  * Tech Stack Card Component
  */
-function TechStackCard({ stack }: { stack: TechSummary }) {
+function TechStackCard({
+  stack,
+}: {
+  stack: TechSummary;
+}) {
   // Generate a color based on the tech name for consistency
   const getColor = (name: string) => {
     const colors = [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@prisma/client': false
+  '@prisma/engines': false
+  prisma: false
+  sharp: false
+  unrs-resolver: false


### PR DESCRIPTION
Closes #110

## Summary

This PR enhances the comparison section by highlighting the corresponding chart data when a user hovers over a technology item.

## Changes

* Added hover interaction for comparison items
* Highlighted the associated chart segment/series on hover
* Improved visual feedback and chart readability

## Benefits

* Makes it easier to associate technologies with their chart data
* Improves comparison experience
* Provides more intuitive visual feedback

## Demo

### Before

https://github.com/user-attachments/assets/995090f8-1ca3-4f05-ad0b-4dd159f4051c

### After

https://github.com/user-attachments/assets/8c64ddf0-f7a4-4981-b7bc-7958467104b6






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tech-stack chart with interactive legend—hover or focus on technology items to highlight their corresponding chart lines for improved visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->